### PR TITLE
Keep instantaneous duration code when specified

### DIFF
--- a/shef/shef_parser.py
+++ b/shef/shef_parser.py
@@ -2994,7 +2994,10 @@ class ShefParser :
                 elif interval_unit == 'Y' :
                     duration_code += 4000
                 try :
-                    duration_id = self._duration_ids[duration_code]
+                    if parameter_code[2] == "I":
+                        duration_id = "I"
+                    else:
+                        duration_id = self._duration_ids[duration_code]
                 except KeyError :
                     self.error(f"No valid duration code for time interval [{token}]")
                     return [] if self._reject_problematic else outrecs


### PR DESCRIPTION
Do not compute a new duration code based on the time interval specifier if the duration code begins as "I" (instantaneous).

@perrymanmd This seemed like the most straightforward way to solve this.  Open to suggestions if there's a better route.