### PR TITLE
Reset SHEF value if first value raises exception

### DIFF
--- a/shef/loaders/base_loader.py
+++ b/shef/loaders/base_loader.py
@@ -96,13 +96,13 @@ class BaseLoader :
                 #-------------#
                 self._shef_value = shef_value
                 try:
-                    self.time_series_name
+                    self.time_series_name  # Test for valid time_series_name property
                     if self.use_value :
                         self._time_series.append([self.date_time, self.value, self.data_qualifier, self.forecast_date_time])
                 except (KeyError, shared.LoaderException) as e:
                     if self._logger:
                         self._logger.error(shared.exc_info(e))
-                    self._shef_value = None
+                    self._shef_value = None  # Reset _shef_value until valid value found
             else :
                 #-------------------#
                 # subsequent values #

--- a/shef/loaders/base_loader.py
+++ b/shef/loaders/base_loader.py
@@ -95,8 +95,14 @@ class BaseLoader :
                 # first value #
                 #-------------#
                 self._shef_value = shef_value
-                if self.use_value :
-                    self._time_series.append([self.date_time, self.value, self.data_qualifier, self.forecast_date_time])
+                try:
+                    self.time_series_name
+                    if self.use_value :
+                        self._time_series.append([self.date_time, self.value, self.data_qualifier, self.forecast_date_time])
+                except (KeyError, shared.LoaderException) as e:
+                    if self._logger:
+                        self._logger.error(shared.exc_info(e))
+                    self._shef_value = None
             else :
                 #-------------------#
                 # subsequent values #

--- a/shef/shef_parser.py
+++ b/shef/shef_parser.py
@@ -91,14 +91,20 @@ versions = '''
 |       |           |     |   * Can be called directly from other scripts                           |
 |       |           |     | Improved exception handling and logging                                 |
 +-------+-----------+-----+-------------------------------------------------------------------------+
+| 1.3.1 | 08Aug2024 | JBK | Two bug fixes:                                                          |
+|       |           |     | * Instantaneous SHEF values no longer parsed as averaged in .E files    |
+|       |           |     | * Error in first SHEF value time_series_name no longer causes errors    |
+|       |           |     |   for all following values.
++-------+-----------+-----+-------------------------------------------------------------------------+
 
 Authors:
     MDP  Mike Perryman, USACE IWR-HEC
+    JBK  Brandon Kolze, USACE LRL-WM
 '''
 
 progname     = Path(sys.argv[0]).stem
-version      = "1.3.0"
-version_date = "26Jul2024"
+version      = "1.3.1"
+version_date = "08Aug2024"
 logger       = logging.getLogger()
 
 def exc_info(e: Exception) -> str :


### PR DESCRIPTION
Keep setting _shef_value to None until a recognized (and used) SHEF value is read.  This avoids raising an exception on every subsequent time_series_name call.

@perrymanmd This doesn't necessarily feel like the most elegant way to handle this to me (especially the bare self.time_series_name expression) but it's relatively concise and fixed the issue for the tests I threw at it.