### PR TITLE
Support custom output streams (Airflow StreamLogWriter)

### DIFF
--- a/shef/loaders/__init__.py
+++ b/shef/loaders/__init__.py
@@ -118,17 +118,17 @@ See https://github.com/HydrologicEngineeringCenter/SHEF_processing/blob/master/s
 
 __all__ : list = []
 
-from loaders.shared import LoaderException
+from shef.loaders.shared import LoaderException
 
 error_modules = []
-try    : from loaders import base_loader
+try    : from shef.loaders import base_loader
 except : raise Exception("ERROR|Cannot import base_loader")
 
-try    : from loaders import cda_loader
+try    : from shef.loaders import cda_loader
 except : error_modules.append("cda_loader")
 
-try    : from loaders import dssvue_loader
+try    : from shef.loaders import dssvue_loader
 except : error_modules.append("dssvue_loader")
 
-try    : from loaders import shefdss_util
+try    : from shef.loaders import shefdss_util
 except : error_modules.append("shefdss_util")

--- a/shef/loaders/base_loader.py
+++ b/shef/loaders/base_loader.py
@@ -1,5 +1,5 @@
 import re
-from loaders  import shared
+from shef.loaders import shared
 from datetime import timedelta
 from logging  import Logger
 from io       import BufferedRandom

--- a/shef/loaders/cda_loader.py
+++ b/shef/loaders/cda_loader.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
     cast,
 )
-from loaders import base_loader, shared
+from shef.loaders import base_loader, shared
 import cwms  # type: ignore
 
 

--- a/shef/loaders/dssvue_loader.py
+++ b/shef/loaders/dssvue_loader.py
@@ -1,6 +1,6 @@
 import csv, os, re, traceback
-from loaders  import base_loader
-from loaders  import shared
+from shef.loaders  import base_loader
+from shef.loaders  import shared
 from datetime import timedelta
 from logging  import Logger
 from io       import BufferedRandom

--- a/shef/shef_parser.py
+++ b/shef/shef_parser.py
@@ -98,6 +98,8 @@ versions = '''
 +-------+-----------+-----+-------------------------------------------------------------------------+
 | 1.4.0 | 12Aug2024 | JBK | Add input_stream argument to parse() function                           |
 +-------+-----------+-----+-------------------------------------------------------------------------+
+| 1.4.1 | 14Aug2024 | JBK | Support custom output objects that implement TextIO                     |
++-------+-----------+-----+-------------------------------------------------------------------------+
 
 Authors:
     MDP  Mike Perryman, USACE IWR-HEC
@@ -105,8 +107,8 @@ Authors:
 '''
 
 progname     = Path(sys.argv[0]).stem
-version      = "1.4.0"
-version_date = "12Aug2024"
+version      = "1.4.1"
+version_date = "14Aug2024"
 logger       = logging.getLogger()
 
 def exc_info(e: Exception) -> str :

--- a/shef/shef_parser.py
+++ b/shef/shef_parser.py
@@ -1957,14 +1957,13 @@ class ShefParser :
         '''
         if self._output :
             self.close_output()
-        if isinstance(output_object, (BufferedRandom, TextIOWrapper)) :
-            self._output = output_object
-            self._output_name = output_object.name
         elif isinstance(output_object, str) :
             self._output = open(output_object, "a+b" if append else "w+b")
             self._output_name = output_object
         else :
-            raise ShefParser.OutputException(f"Expected BufferedRandom or str object, got [{output_object.__class__.__name__}]")
+            # IO typing is wonky -- see https://github.com/python/typeshed/issues/6077
+            self._output = output_object  # type: ignore
+            self._output_name = output_object.name
         logger.debug(f"Data output set to {self._output_name}")
 
     def output(self, outrec : OutputRecord) -> None :
@@ -1975,12 +1974,13 @@ class ShefParser :
             if not self._output :
                 raise ShefParser.OutputException("Cannot output record; output is closed or never opened")
             outstr = f"{outrec.format(self._output_format)}\n"
-            if isinstance(self._output, TextIOWrapper) :
-                self._output.write(outstr)
-            elif isinstance(self._output, BufferedRandom) :
-                self._output.write(outstr.encode("utf-8"))
-            else :
-                raise ShefParser.OutputException(f"Unexpected output device type: {self._output.__class__.__name__}")
+            try:
+                if isinstance(self._output, BufferedRandom) :
+                    self._output.write(outstr.encode("utf-8"))
+                else :
+                    self._output.write(outstr)
+            except Exception as e:
+                raise ShefParser.OutputException(f"Unexpected output device type: {self._output.__class__.__name__}") from e
 
     def remove_comment_fields(self, line: str) -> str :
         '''


### PR DESCRIPTION
Depends on #24 

The general idea here is to assume that the provided/available output object implements the ```TextIO``` interface unless otherwise specified.  This got a little messy since it turns out that python's IO types themselves are somewhat of a mess.  See: https://github.com/python/typeshed/issues/6077

The previous typing uses both ```TextIO``` and ```TextIOWrapper``` from the ```typing``` and ```io``` libraries, respectively, which are actually incompatible (which seems odd, but nonetheless...).  The conflict was somewhat avoided by pseudo-casting the ```TextIO``` to ```TextIOWrapper``` using an ```isinstance()``` call:

https://github.com/HydrologicEngineeringCenter/SHEF_processing/blob/174d5f7c54a92a6cb9c224b1335354f9b4dba7ea/shef/shef_parser.py#L1954-L1968

This causes issues with the new approach, however, because we're basically assuming that TextIOWrapper implements TextIO without explicitly telling the interpreter.  Hence, suppressing the mypy error here:

https://github.com/HydrologicEngineeringCenter/SHEF_processing/blob/4566d8e4f128971da1daf9fdbacf6c0fa4788ecd/shef/shef_parser.py#L1954-L1967

Tested both from the CLI and in Airflow and everything seems to be working as expected.

Note: I didn't adjust the dssvue_loader because I don't know of a use case in which it will be run in Airflow, but that can be adjusted as well if need be.