### PR TITLE
cda_loader v0.2

### DIFF
--- a/shef/loaders/cda_loader.py
+++ b/shef/loaders/cda_loader.py
@@ -127,7 +127,11 @@ class CdaLoader(base_loader.BaseLoader):
         cwms.init_session(api_root=self._cda_url, api_key=f"apikey {cda_api_key}")
 
         shef_group = cwms.get_timeseries_group(
-            "SHEF Data Acquisition", "Data Acquisition", "CWMS"
+            office_id="LRL",
+            group_office_id="CWMS",
+            category_office_id="CWMS",
+            group_id="SHEF Data Acquisition",
+            category_id="Data Acquisition",
         ).json
         try:
             for time_series in shef_group["assigned-time-series"]:
@@ -383,7 +387,7 @@ loader_options = (
     "--loader cda[cda_api_key]\n"
     "cda_api_key = the api_key to use for CDA POST requests\n"
 )
-loader_description = "Used to import SHEF data through cwms-data-api.  Requires cwms-python v0.3.0 or greater."
+loader_description = "Used to import SHEF data through cwms-data-api.  Requires cwms-python v0.6.0 or greater."
 loader_version = "0.2"
 loader_class = CdaLoader
 can_unload = False

--- a/shef/loaders/cda_loader.py
+++ b/shef/loaders/cda_loader.py
@@ -70,7 +70,7 @@ class CdaLoader(base_loader.BaseLoader):
         Constructor
         """
         super().__init__(logger, output_object, append)
-        self._cda_url = "https://cwms-data-test.cwbi.us/cwms-data/"
+        self._cda_url: str = ""
         self._office_code: str = ""
         self._parsed_payloads: list[TimeseriesPayload] = []
         self._payloads: list[TimeseriesPayload] = []
@@ -81,7 +81,7 @@ class CdaLoader(base_loader.BaseLoader):
 
     def set_options(self, options_str: Union[str, None]) -> None:
         """
-        Set the office code and CDA apikey
+        Set the office code, CDA URL, and CDA apikey
         """
         if not options_str:
             raise shared.LoaderException(
@@ -118,12 +118,13 @@ class CdaLoader(base_loader.BaseLoader):
             )
 
         options = tuple(re.findall(r"\[(.*?)\]", options_str))
-        if len(options) == 2:
+        if len(options) == 3:
             self._office_code = options[0]
-            cda_api_key = options[1]
+            self._cda_url = options[1]
+            cda_api_key = options[2]
         else:
             raise shared.LoaderException(
-                f"{self.loader_name} expected 2 options, got [{len(options)}]"
+                f"{self.loader_name} expected 3 options, got [{len(options)}]"
             )
 
         cwms.init_session(api_root=self._cda_url, api_key=f"apikey {cda_api_key}")
@@ -388,6 +389,7 @@ class CdaLoader(base_loader.BaseLoader):
 loader_options = (
     "--loader cda[office_code][cda_api_key]\n"
     "office_code = the 3-letter code of the office owning the time series data\n"
+    "cda_url     = the url of the CDA instance to be used, e.g. https://cwms-data.usace.army.mil/cwms-data/\n"
     "cda_api_key = the api_key to use for CDA POST requests\n"
 )
 loader_description = "Used to import SHEF data through cwms-data-api.  Requires cwms-python v0.6.0 or greater."

--- a/shef/loaders/cda_loader.py
+++ b/shef/loaders/cda_loader.py
@@ -6,6 +6,7 @@ from logging import Logger
 import re
 import time
 from typing import (
+    Any,
     Callable,
     Coroutine,
     NamedTuple,
@@ -208,8 +209,11 @@ class CdaLoader(base_loader.BaseLoader):
         """
         Create an async CDA POST request coroutine for provided post_data
         """
+        post_data_dict = cast(dict[str, Any], post_data)
         return asyncio.to_thread(
-            cwms.store_timeseries, data=post_data, store_rule="REPLACE WITH NON MISSING"
+            cwms.store_timeseries,
+            data=post_data_dict,
+            store_rule="REPLACE WITH NON MISSING",
         )
 
     async def process_write_tasks(self) -> None:


### PR DESCRIPTION
Update cda_loader to v0.2 with added features:
- update to use latest cwms_python (v0.6)
- retrieve criteria data from CWMS rather than file
- re-configure loader options:
  - office_code
  - cda_url
  - cda_apikey
- adjust async requests to limit MAX_CONNECTIONS