### PR TITLE
Feature/cda office from group

### DIFF
--- a/shef/loaders/cda_loader.py
+++ b/shef/loaders/cda_loader.py
@@ -408,7 +408,7 @@ loader_options = (
     "cda_url     = the url of the CDA instance to be used, e.g. https://cwms-data.usace.army.mil/cwms-data/\n"
     "cda_api_key = the api_key to use for CDA POST requests\n"
 )
-loader_description = "Used to import SHEF data through cwms-data-api.  Requires cwms-python v0.6.0 or greater."
-loader_version = "0.3"
+loader_description = "Used to import SHEF data through cwms-data-api.  Requires cwms-python v0.6.3 or greater."
+loader_version = "0.3.1"
 loader_class = CdaLoader
 can_unload = False


### PR DESCRIPTION
A couple relatively minor cda_loader updates
- Assume the /timeseries POST office_id based on the office_id associated with the time series in the SHEF time series group
- Address a bug that occurs when a SHEF product contains duplicate values for a single sensor/parameter/time

Requires some updates contained in cwms-python v0.6.3.