### PR TITLE
Add ability to use pre-processed (format 1 and 2) files as input

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "shef-parser"
 repository = "https://github.com/HydrologicEngineeringCenter/SHEF_processing"
 
-version = "1.4.4"
+version = "1.5.0"
 
 
 packages = [


### PR DESCRIPTION
Use the new `--processed` command line argument to pass a pre-processed (format 1 or 2) file to a loader.