### PR TITLE
Add Exporters

### DIFF
--- a/examples/cda_export_example.py
+++ b/examples/cda_export_example.py
@@ -1,0 +1,52 @@
+import os
+from datetime import datetime, timedelta
+from io import StringIO
+
+from shef.exporters import CdaExporter
+
+exporter = CdaExporter(os.getenv("cda_api_root", ""), "SWT")
+# ---------------------------------------- #
+# export an entire group for a time window #
+# ---------------------------------------- #
+exporter.end_time = datetime.now()
+exporter.start_time = exporter.end_time - timedelta(days=7)
+group_id = "KEYS"
+print(
+    f"==> Exporting group {group_id} for office {exporter._office} for time window = {exporter.start_time}, {exporter.end_time}"
+)
+exporter.export(group_id)
+# --------------------------------------------------------- #
+# print all the SHEF Export groups for the specified office #
+# --------------------------------------------------------- #
+print(f"==> group IDs and descriptions for office {exporter._office}")
+groups = exporter.get_groups()
+for group_name in groups:
+    print(f"{group_name}\t{groups[group_name]}")
+# ----------------------------- #
+# export individual time series #
+# ----------------------------- #
+exporter.start_time = exporter.end_time - timedelta(days=3)
+group_id = "HULA"
+print(
+    f"==> Exporting individual time series in group {group_id} for office {exporter._office} for time window = {exporter.start_time}, {exporter.end_time}"
+)
+for tsid in exporter.get_time_series(group_id):
+    unit = exporter.get_unit(tsid)
+    print(f"#\n# {tsid} (unit={unit})\n#")
+    exporter.export(tsid)
+# ---------------------------------- #
+# export to buffer instead of stdout #
+# ---------------------------------- #
+exporter.start_time = exporter.end_time - timedelta(days=1)
+group_id = "BROK"
+print(
+    f"==> Exporting individual time series in group {group_id} for office {exporter._office} for time window = {exporter.start_time}, {exporter.end_time} to local buffers we can modify"
+)
+for tsid in exporter.get_time_series(group_id):
+    unit = exporter.get_unit(tsid)
+    with StringIO() as buf:
+        exporter.set_output(buf)
+        buf.write(f"#\n# {tsid} (unit={unit})\n#\n")
+        exporter.export(tsid)
+        s = buf.getvalue()
+        print(s.strip())

--- a/shef/constants.py
+++ b/shef/constants.py
@@ -690,27 +690,27 @@ EXTREMUM_CODES = set(
         #
         # May be modified by SHEFPARM file
         #
-        "D",
-        "E",
-        "F",
-        "G",
-        "H",
-        "I",
-        "J",
-        "K",
-        "L",
-        "M",
-        "N",
-        "P",
-        "R",
-        "S",
-        "T",
-        "U",
-        "V",
-        "W",
-        "X",
-        "Y",
-        "Z",
+        "D",  # Minimum of record
+        "E",  # Minimum of year (calendar)
+        "F",  # Minimum of month
+        "G",  # Minimum of week
+        "H",  # Minimum of day
+        "I",  # Minimum of 1 hour
+        "J",  # Minimum of 3 hours
+        "K",  # Minimum of 6 hours
+        "L",  # Minimum of 12 hours
+        "M",  # Minimum of 18 hours
+        "N",  # Maximum of record
+        "P",  # Maximum of year (calendar)
+        "R",  # Maximum of month
+        "S",  # Maximum of week
+        "T",  # Maximum of day
+        "U",  # Maximum of 1 hour
+        "V",  # Maximum of 3 hours
+        "W",  # Maximum of 6 hours
+        "X",  # Maximum of 12 hours
+        "Y",  # Maximum of 18 hours
+        "Z",  # Null character (filler)
     )
 )
 
@@ -758,24 +758,28 @@ QUALIFIER_CODES = set(
         #
         # May be modified by SHEFPARM file
         #
-        "B",
-        "D",
-        "E",
-        "F",
-        "G",
-        "L",
-        "M",
-        "N",
-        "P",
-        "Q",
-        "R",
-        "S",
-        "T",
-        "V",
-        "W",
-        "Z",
+        "B",  # Bad, Manual QC
+        "D",  # Partial (qual = 4) – A 24 hour period was missing because 1 to 3 of the 6 hour periods was missing. The 24 hour amount is estimated using available/estimated 6 hour periods.
+        "E",  # Estimated (qual = 5)
+        "F",  # Flagged (qual = 1) – Flagged by sensor or telemetry (parity errors, for example)
+        "G",  # Good, Manual QC
+        "L",  # Lumped (qual = 6) - Estimated from the gages that have 6 hourly data with the constraint that the sum of the four 6 hourly periods is equal to the 24 hour amount.
+        "M",  # Manual Edit
+        "N",  # Reserved
+        "P",  # Passed Level1, Level2, Level3
+        "Q",  # Questioned in Level2, Level3 (qual = 3)
+        "R",  # Rejected by Level1
+        "S",  # Screened Level1 (qual = 0)(data value tested using preliminary criteria)
+        "T",  # Triggered (tells database to start some additional function)
+        "V",  # Verified Level1, Level2 (qual = 8)(data value verified using a more rigorous method)
+        "W",  # Withheld (qual = 2) – The precipitation amount was manually input by the user (the measured precipitation was withheld).
+        "Z",  # No QC Performed (null character)
     )
 )
+
+# Level1 = validity checks (i.e. range checking)
+# Level2 = internal and temporal consistency checks (i.e. rate of change checks)
+# Level3 = spatial consistency checks (e.g. temperature and precipitation field outliers)
 
 DEFAULT_DURATION_CODES = {
     #

--- a/shef/exporters/__init__.py
+++ b/shef/exporters/__init__.py
@@ -1,0 +1,7 @@
+__all__ = [
+    "BaseExporter"
+    "CdaExporter"
+]
+
+from .base_exporter import BaseExporter
+from .cda_exporter import CdaExporter

--- a/shef/exporters/base_exporter.py
+++ b/shef/exporters/base_exporter.py
@@ -1,0 +1,101 @@
+import logging
+import sys
+from datetime import datetime
+from io import BufferedRandom, StringIO
+from typing import Optional, TextIO, Union
+from abc import ABC, abstractmethod
+
+import cwms
+
+from shef import loaders
+from shef.loaders import shared
+
+version = "1.0.0"
+version_date = "31Oct2025"
+
+
+class BaseExporter (ABC):
+    """
+    Base class for SHEF exporters
+
+    Loaders that support unloading expect to read a loader-specific time series format from their inputs when unloading.
+
+    Exporters provide the means to select time series data to present to the loaders for unloading. Selecting includes:
+    * Specifying a time window
+    * Specifying time series identifiers in loader-specific formats
+    """
+
+    def __init__(self):
+        """
+        Initializer for BaseExporter class
+        """
+        logging.basicConfig(
+            stream=sys.stderr, format="%(levelname)s: %(msg)s", level=logging.WARNING
+        )
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._output: Optional[Union[BufferedRandom, TextIO, StringIO]] = sys.stdout
+        self._start_time: Optional[datetime] = None
+        self._end_time: Optional[datetime] = None
+
+    @property
+    def end_time(self) -> Optional[datetime]:
+        """
+        The end of the time window to export
+
+        Oprations:
+            Read/Write
+        """
+        return self._end_time
+
+    @end_time.setter
+    def end_time(self, value: Optional[datetime]) -> None:
+        self._end_time = value
+
+    @abstractmethod
+    def export(self, identifier: str) -> None:
+        """
+        Exports SHEF text for the the specified identifier for the current time window to the current export output stream
+
+        Args:
+            identifier (str): The identifier (time series ID, group ID, etc...)
+        """
+
+    def set_output(
+        self,
+        output_object: Optional[Union[BufferedRandom, TextIO, StringIO]],
+    ) -> None:
+        """
+        Sets the output stream for subsequent exports. All exports go to the system standard output device (sys.stdout)
+        unless redirected by this call.
+
+        Notably this can be set to a StringIO object in order to capture the output for further processing
+
+        Example:
+            ```
+            exporter = CdaExporter(api_root, api_key, office)
+            exporter.start_time = start_time
+            exporter.end_time = end_time
+            with StringIO() as buf:
+                exporter.set_output(buf)
+                exporter.export(tsid)
+                export_data = buf.getvalue()
+            # work with export_data as desired
+            ```
+        Args:
+            output_object (Optional[Union[BufferedRandom, TextIO, StringIO]]): A file-like object to use as the export output stream
+        """
+        self._output = output_object
+
+    @property
+    def start_time(self) -> Optional[datetime]:
+        """
+        The start of the time window to export
+
+        Oprations:
+            Read/Write
+        """
+        return self._start_time
+
+    @start_time.setter
+    def start_time(self, value: Optional[datetime]) -> None:
+        self._start_time = value

--- a/shef/exporters/cda_exporter.py
+++ b/shef/exporters/cda_exporter.py
@@ -1,0 +1,119 @@
+import json
+import sys
+from datetime import datetime, timedelta
+from io import BufferedRandom, StringIO
+from typing import Any, Optional, TextIO, Union
+
+import cwms
+
+from shef import loaders
+from shef.loaders import shared
+from shef.exporters import BaseExporter
+
+class CdaExporter(BaseExporter):
+    """
+    Helper class for using CdaLoader to export SHEF values.
+
+    Like all loaders that support unloading, CdaLoader expects to read a loader-specific time series format from its input when unloading -
+    lists of json objects from cda in this case. This class provides high level methods for feeding the desired data to CdaLoader in the
+    expected format.
+    """
+
+    class NamedStringIO(StringIO):
+        """
+        A simple StringIO subclass that provides a name attribute (expected by CdaLoader)
+        """
+        def __init__(self, content: Optional[str] = None):
+            super().__init__(content)
+            self.name = "<streamed input>"
+
+    def __init__(self, api_root: str, office: str):
+        """
+        Initializer for CdaExporter class
+
+        Args:
+            api_root (str): The CDA API root
+            office (str): The office id to use
+        """
+        super().__init__()
+        if not all([api_root, office]):
+            raise shared.LoaderException("Must specifiy api_root, api_key and office")
+        self._api_root = api_root
+        self._office = office
+        self._cda_loader = loaders.cda_loader.CdaLoader(self._logger, sys.stdout)
+        self._cda_loader.set_options(f"[{api_root}][][{office}]")
+        self._cda_loader.make_export_transforms()
+
+    def export(self, timeseries_or_group: str) -> None:
+        """
+        Exports the specified time series or group for the current time window to the current export output stream
+
+        Args:
+            timeseries_or_group (str): If a time series ID, export that time series; If a time series group ID, export each time series in that group
+        """
+        if len(timeseries_or_group.split(".")) == 6:
+            timeseries_ids = [timeseries_or_group]
+        elif timeseries_or_group in self._cda_loader._export_groups:
+            timeseries_ids = self._cda_loader._export_groups[timeseries_or_group][
+                "timeseries"
+            ]
+        data = StringIO()
+        data.write("[")
+        for i, tsid in enumerate(timeseries_ids):
+            if i > 0:
+                data.write(",")
+            unit = self._cda_loader._transforms[tsid].units
+            ts = cwms.get_timeseries(
+                ts_id=tsid,
+                office_id=self._cda_loader._office_id,
+                unit=unit,
+                begin=self._start_time,
+                end=self._end_time,
+            )
+            data.write(json.dumps(ts.json))
+        data.write("]")
+        self._cda_loader.set_input(CdaExporter.NamedStringIO(data.getvalue()))
+        data.close()
+        try:
+            old_output = self._cda_loader._output
+            self._cda_loader._output = self._output
+            self._cda_loader.unload()
+        finally:
+            self._cda_loader._output = old_output
+            self._cda_loader._input = None
+
+    def get_groups(self) -> dict[str, str]:
+        """
+        Retrieves time series groups under the "SHEF Export" time series category for the exporter's office
+
+        Returns:
+            dict[str, str]: A dictionary of time series group descriptions keyed by time series group IDs
+        """
+        return {
+            group: self._cda_loader._export_groups[group]["description"]
+            for group in self._cda_loader._export_groups
+        }
+
+    def get_time_series(self, group: str) -> list[str]:
+        """
+        Retrieves the time series assigned to the specifed time series group under the "SHEF Export" time series category
+
+        Args:
+            group (str): The time series group ID
+
+        Returns:
+            list[str]: The assigned time series IDs
+        """
+        return [ts for ts in self._cda_loader._export_groups[group]["timeseries"]]
+
+    def get_unit(self, tsid: str) -> Optional[str]:
+        """
+        Retrieves the SHEF standard unit as specified in the alias for the specified time series
+
+        Args:
+            tsid (str): The time series to specify the SHEF standard unit for
+
+        Returns:
+            Optional[str]: The unit as specified in the time series alias
+        """
+        return self._cda_loader._transforms[tsid].units

--- a/shef/shef_parser.py
+++ b/shef/shef_parser.py
@@ -2325,7 +2325,7 @@ class ShefParser:
                                 y, m, d, h, n, s = list(
                                     map(int, [_y, _m, _d, _h, _n, _s])
                                 )
-                                if all([y, m, d, h, n, s]) :
+                                if all([y, m, d, h, n, s]):
                                     create_time = ShefParser.DateTime(
                                         y, m, d, h, n, s, tzinfo=ZoneInfo("UTC")
                                     )


### PR DESCRIPTION
## Add Exporters
Exporters are needed to:
1. be able to select time windows and time series for extraction
2. extract the selected time series
3. present the extracted time series in loader-specific data format for unloading (generation of SHEF text)

Exporters use the `unload()` method of the associated loader to generate SHEF text

`DSSVueLoader` doesn't need a standalone exporter because HEC-DSSVue provides that function. CWMS-Vue could provide the same functionality for the `CdaLoader`, but it currently doesn't.

The new `CdaExporter` class provides the functionality for a python script to use the `CdaLoader` to export time series in SHEF format; a future `DssExporter` could do the same for either the `DSSVueLoader` or a new variant specific to HEC-DSS.

This PR includes a `cda_export_example.py` file that demonstrates using the CdaExporter to generate SHEF from a CWMS database.

## CWMS Configuration for Exporting SHEF data
In order to use `CdaExporter`, the SHEF export configuration information must be present in the CWMS database. Specifically:
1. A CWMS-owned time series group category named `SHEF Export` must exist.
2. One or more office-owned time series groups must exist under the `SHEF Export` category
3. One or more time series must be assigned to the time series group(s)
4. The alias(es) for the time time series must be of the format:
    a. SHEF location identifier, followed by a `.`
    b. SHEF PE code, followed by a `.`
    c. SHEF TS code
    d. SHEF Extremum code, followed by a `.`
    e. SHEF duration numeric, followed by a `:`
    f. SHEF units, specified as `Units=<unit>`

An example configuration is shown:
<img width="1253" height="891" alt="image" src="https://github.com/user-attachments/assets/142dc11e-8db1-4a6c-8a60-8449e5cb4b11" />
